### PR TITLE
fix: redirect feedback reward bounties to submissions

### DIFF
--- a/src/components/cards/Bounty.tsx
+++ b/src/components/cards/Bounty.tsx
@@ -111,6 +111,7 @@ export default function BountyCard({ bounty }: BountyProps): ReactElement {
           shape="rounded"
           className="w-15 h-15 rounded-xl overflow-hidden"
           user={null}
+          useLink={false}
         />
         {bounty.submissions?.length ? (
           <Badge


### PR DESCRIPTION
This pull request aims to redirect feedback reward bounties to the submissions.

Closes #594 