### PR TITLE
fix: allow selecting a new team member when there is no existing team

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -119,7 +119,7 @@
   "communities.overview.challenge.team.setup.info": "To complete the team challenge, you need to follow these steps:",
   "communities.overview.challenge.team.setup.submit-title": "Submit your team",
   "communities.overview.challenge.submission.description": "Paste the code of your team below and it will automatically link to all the profiles",
-  "communities.challenge.submission.hint": "Submitions will be enabled when when all the team mebmers accept the invitation and the team is fully formed.",
+  "communities.challenge.submission.hint": "Submitions will be enabled when when all the team members accept the invitation and the team is fully formed.",
   "communities.overview.challenge.deadline": "Deadline",
   "communities.challenge.hint": "Hint",
   "communities.challenge.criteria.title": "Rating Rubric",

--- a/src/components/cards/SubmissionTeam.tsx
+++ b/src/components/cards/SubmissionTeam.tsx
@@ -27,7 +27,7 @@ interface SubmissionTeamCardProps {
  * @typedef {TeamCandidate}
  */
 interface TeamCandidate {
-  user?: User;
+  user?: User | null;
   status: string;
 }
 
@@ -98,7 +98,7 @@ export default function SubmissionTeamCard({ index = 1, title = "", text = "" }:
 
   useEffect(() => {
     if (team) {
-      setMembersList([{ user: team.organizer, status: "organizer" }]);
+      if (team.organizer) setMembersList([{ user: team.organizer, status: "organizer" }]);
 
       if (team.teamMembers) {
         team.teamMembers.forEach((member) => {
@@ -123,7 +123,9 @@ export default function SubmissionTeamCard({ index = 1, title = "", text = "" }:
     if (membersList.filter((member) => member.user?.id === option.user?.id).length !== 0) {
       return;
     }
-    setMembersList([...membersList, { user: option.user, status: "Sending invite" }]);
+    if (membersList.length === 0) setMembersList([{ user, status: "organizer" }]);
+
+    setMembersList((prev) => [...prev, { user: option.user, status: "Sending invite" }]);
     await dispatch(
       createTeam({
         challenge_id: challenge?.id,
@@ -205,7 +207,9 @@ export default function SubmissionTeamCard({ index = 1, title = "", text = "" }:
                 loadOptions={loadUserOptions}
                 onChange={(option) => {
                   // TODO: check if the team is actually closed instead of using this condition
-                  if (team.teamMembers && team.teamMembers?.length < 2) {
+                  if (team?.teamMembers && team.teamMembers.length >= 2) {
+                    return;
+                  } else {
                     if (option) selectTeamMember(option);
                   }
                 }}

--- a/src/components/sections/challenges/Submission.tsx
+++ b/src/components/sections/challenges/Submission.tsx
@@ -109,7 +109,7 @@ export default function Submission(): ReactElement {
   return (
     <Section title={t("communities.challenge.submission")}>
       {challenge?.isTeamChallenge && <p className="text-base font-normal text-slate-700 pt-2 pb-7 md:w-99">{t("communities.overview.challenge.submission.description")}</p>}
-      {team?.teamMembers && team.teamMembers.length < 3 && challenge?.isTeamChallenge ? (
+      {(team?.teamMembers && team.teamMembers.length === 2 && challenge?.isTeamChallenge) || !team ? (
         <Hint className="mb-8">{t("communities.challenge.submission.hint")}</Hint>
       ) : (
         <form onSubmit={handleSubmit(onSubmit)}>


### PR DESCRIPTION
## Tasks done
To test this you need to use an account that does not belong to any team 

1. fix: Allow selection of a new member when no team exists
2. fix: Hide the submission form, when the account does neither have an invite nor belong to a team
3. Remove the blue circle which appears when no team exists

