### PR TITLE
fix: show selected user's profile instead of the current user

### DIFF
--- a/src/layouts/RequireAuth.tsx
+++ b/src/layouts/RequireAuth.tsx
@@ -76,9 +76,9 @@ export default function RequireAuth({ children }: { children: ReactNode }): Reac
     }
 
     if (route.startsWith("/profile") && auth && auth.emailVerified) {
-      const username = router.query.username ? router.query.username : authUser?.username;
-      dispatch(fetchUserProfile((username as string) || ""));
-      dispatch(fetchAllProfileCommunities((authUser?.username as string) || authUser?.displayName || ""));
+      const username = (router.query.username as string) || authUser?.username || "";
+      dispatch(fetchUserProfile(username));
+      dispatch(fetchAllProfileCommunities(username || authUser?.displayName || ""));
     }
   }, [auth, authUser, dispatch, isGuestRoute, isUserRoute, route, router]);
 


### PR DESCRIPTION
Initially when you clicked on another person's profile when you are logged in, your profile is the one that showed up.

This PR fixes it