### PR TITLE
feat: re-fetch the team after every team modification

### DIFF
--- a/src/store/feature/communities/challenges/invites.slice.ts
+++ b/src/store/feature/communities/challenges/invites.slice.ts
@@ -4,11 +4,9 @@ import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 
 interface DefaultState {
   data: Invite | null;
-  inviteStatus: string | null;
 }
 const defaultState: DefaultState = {
   data: null,
-  inviteStatus: null,
 };
 
 /**
@@ -24,13 +22,10 @@ const invitesSlice = createSlice({
     setInvitesData: (state, action) => {
       state.data = action.payload;
     },
-    setInviteStatus: (state, action) => {
-      state.inviteStatus = action.payload;
-    },
   },
 });
 
-export const { setInvitesData, setInviteStatus } = invitesSlice.actions;
+export const { setInvitesData } = invitesSlice.actions;
 
 /**
  * Accept team invitation action

--- a/src/store/services/teams.service.ts
+++ b/src/store/services/teams.service.ts
@@ -1,7 +1,7 @@
 import baseQuery from "@/config/baseQuery";
 import { createApi } from "@reduxjs/toolkit/dist/query/react";
 import { setIsTeamDataLoading, setTeamData } from "../feature/teams.slice";
-import { setInviteStatus, setInvitesData } from "../feature/communities/challenges/invites.slice";
+import { setInvitesData } from "../feature/communities/challenges/invites.slice";
 import { Invite } from "@/types/challenge";
 
 /**
@@ -36,6 +36,7 @@ interface RemoveMemberPayload {
  */
 const teamsService = createApi({
   reducerPath: "teamsService",
+  refetchOnMountOrArgChange: true,
   baseQuery: baseQuery(),
   endpoints: (builder) => ({
     getTeamByChallenge: builder.query({
@@ -83,16 +84,11 @@ const teamsService = createApi({
         method: "POST",
         body: payload,
       }),
-      onQueryStarted: async (payload, { dispatch, queryFulfilled }) => {
+      onQueryStarted: async (payload, { queryFulfilled }) => {
         try {
-          const { data } = await queryFulfilled;
-          if (data.invites.length > 0) dispatch(setInviteStatus("sent"));
-          else dispatch(setInviteStatus("not sent"));
+          await queryFulfilled;
         } catch (err: any) {
-          dispatch(setInviteStatus(err.status));
           console.error("Error", err);
-        } finally {
-          teamsService.endpoints.getTeamByChallenge.initiate(payload.challenge_id as string);
         }
 
         return;


### PR DESCRIPTION
Actions done:

* Remove `inviteStatus` state which was no longer needed
* add a re-fetch function on every team modification (inviting a member, cancelling team invite,  removing a member)

## Unable to test the UI on deployment, waiting for #692 