### PR TITLE
fix: hide address for wallets with DAC token in the profile dropdown.

### DIFF
--- a/src/components/cards/Balance.tsx
+++ b/src/components/cards/Balance.tsx
@@ -27,7 +27,7 @@ interface BalanceProps {
  * @returns {ReactElement}
  */
 export default function Balance({ details }: BalanceProps): ReactElement {
-  const address = details.address && details.token !== "DAC" ? truncateAddress(details.address, details.token) : null;
+  const address = details.address && details.token.toUpperCase() !== "DAC" ? truncateAddress(details.address, details.token) : null;
 
   return (
     <Link href="/profile/wallets">


### PR DESCRIPTION
Closes #839 