### PR TITLE
fix: remove learning modules list in the challenge header

### DIFF
--- a/src/components/sections/challenges/Header.tsx
+++ b/src/components/sections/challenges/Header.tsx
@@ -1,6 +1,5 @@
 import Section from "@/components/sections/communities/_partials/Section";
 import Header from "@/components/sections/communities/_partials/Header";
-import ObjectiveList from "@/components/list/Objectives";
 import { useSelector } from "@/hooks/useTypedSelector";
 import { useTranslation } from "next-i18next";
 import { ReactElement } from "react";
@@ -19,9 +18,7 @@ export default function ChallengeHeader(): ReactElement {
   return (
     <div>
       <Header isTeamChallenge={challenge?.isTeamChallenge} title={challenge?.name} subtitle={t("communities.challenge.title")} isHackathon={challenge?.isHackathon} />
-      <Section subtitle={challenge?.description}>
-        {challenge?.learningModules?.length ? <ObjectiveList objectives={challenge?.learningModules?.map((module) => module.title) || []} /> : <></>}
-      </Section>
+      <Section subtitle={challenge?.description} />
     </div>
   );
 }

--- a/src/components/sections/communities/_partials/Section.tsx
+++ b/src/components/sections/communities/_partials/Section.tsx
@@ -15,7 +15,7 @@ interface SectionProps {
   id?: string;
   className?: string;
   hideSubtitleOnMobile?: boolean;
-  children: ReactNode;
+  children?: ReactNode;
 }
 
 /**


### PR DESCRIPTION
This removes the below learning modules check box

![image](https://github.com/dacadeorg/dacade-frontend-app/assets/70019756/d8cdc290-af49-4171-824f-c59f3e1effd1)

Closes #963 