### PR TITLE
fix: show the KYC verify button only when viewing own profile

### DIFF
--- a/src/components/sections/profile/Header.tsx
+++ b/src/components/sections/profile/Header.tsx
@@ -60,8 +60,8 @@ export default function ProfileHeader() {
   const isCurrentUser = useMemo(() => username?.toLowerCase() === authUser?.displayName?.toLowerCase(), [authUser, username]);
 
   const showKycVerificationButton = useMemo(() => {
-    return isCurrentUser && !user?.isKycVerified;
-  }, [isCurrentUser, user?.isKycVerified]);
+    return isCurrentUser && !isKycVerified;
+  }, [isCurrentUser, isKycVerified]);
 
   const dispatch = useDispatch();
   const triggerKYCVerification = () => {


### PR DESCRIPTION
Fixing a bug left out by #968 .
Closes #981 