### PR TITLE
fix: create a linkOverlay for reputation card and fix spacing 

### DIFF
--- a/src/components/cards/Reputation.tsx
+++ b/src/components/cards/Reputation.tsx
@@ -32,10 +32,16 @@ interface ReputationCardProps {
  */
 export default function ReputationCard({ details = {} }: ReputationCardProps): ReactElement {
   return (
-    <div className="flex space-x-3 text-left hover:bg-gray-50 pb-3 -mx-5 px-5">
-      <Avatar icon={details.community?.icon} color={details.community?.colors?.cover?.background || details.community?.colors.primary} size="medium" shape="rounded" />
+    <div className="flex space-x-3 text-left hover:bg-gray-50 py-3 -mx-5 px-5 relative">
+      <Avatar
+        icon={details.community?.icon}
+        color={details.community?.colors?.cover?.background || details.community?.colors.primary}
+        size="medium"
+        shape="rounded"
+        useLink={false}
+      />
       {details?.score && (
-        <Link href={details?.community ? `/communities/${details.community.slug}` : ""} className="pt-1">
+        <Link href={details?.community ? `/communities/${details.community.slug}` : ""} className="pt-1 before:content-[''] before:absolute before:top-0 before:left-0 before:w-full before:h-full before:z-0 before:block">
           <span className="block text-base font-medium leading-normal">
             <Currency value={details.score} token="REP" />
           </span>


### PR DESCRIPTION
# Submit a pull request

- [x] This is not a duplicate of an existing pull request.
- [x] No existing features have been broken without good reason.
- [x] Your commit messages are detailed
- [x] The code style guideline have been followed.
- [ ] Documentation has been updated to reflect your changes.
- [ ] Tests have been added or updated to reflect your changes.
- [ ] All tests pass.

---

## Pull Request Details

this PR creates a linkOverlay in the reputation card using CSS approach to avoid wrapping the whole card in a link tag and add equal spacing

## Breaking Changes

none

## Issues Fixed
This PR fixes the unequal spacing on the reputation card
It fixes the inconsistency of links in the reputation card to have the same link

