### PR TITLE
fix: show 'next' button on challenge/learning-modules page

### DIFF
--- a/src/components/sections/courses/PageNavigation.tsx
+++ b/src/components/sections/courses/PageNavigation.tsx
@@ -87,7 +87,7 @@ export default function PageNavigation(): ReactElement {
    */
   const nextUrl: string | null = useMemo(() => {
     const index = currentIndex + 1;
-    if (index < list?.length - 1 && list[index]?.link) {
+    if (currentIndex < list?.length - 1 && list[index]?.link) {
       return list[index].link;
     }
     return null;


### PR DESCRIPTION
# Submit a pull request

- [ ] This is not a duplicate of an existing pull request.
- [ ] No existing features have been broken without good reason.
- [ ] Your commit messages are detailed
- [ ] The code style guideline have been followed.
- [ ] Documentation has been updated to reflect your changes.
- [ ] Tests have been added or updated to reflect your changes.
- [ ] All tests pass.

---
## Bug: learning materials in a challenge does not have the same bottom navigation as the learning materials that are in a course.

## Issues Fixed

Closes #1255 

Provide any other important details below.

Current view:

https://staging-dacade.netlify.app/communities/icp/challenges/07804763-fdad-5620-8361-60cc592b0a75/learning-modules/3e7f0a89-398c-457d-99ec-3f41d0b238c3

The fix: https://deploy-preview-1257--staging-dacade.netlify.app/communities/icp/challenges/07804763-fdad-5620-8361-60cc592b0a75/learning-modules/3e7f0a89-398c-457d-99ec-3f41d0b238c3

## TIP. Scroll to the bottom
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected navigation logic to ensure the correct next URL is retrieved based on the current index in the course navigation component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->