### PR TITLE
fix: display learning module level regardless of the challenge level

### DIFF
--- a/src/components/cards/LearningModule.tsx
+++ b/src/components/cards/LearningModule.tsx
@@ -24,9 +24,9 @@ export function LearningModuleCard({ data }: { data: LearningModule }): JSX.Elem
   })
 
   const level = useMemo(() => {
-    const value = data?.level || challenge?.level;
+    const value = data?.level;
     return t((value === 0 || value === 1) ? "course.challenge.level-0" : "course.challenge.level-2");
-  }, [challenge?.level]);
+  }, [data?.level]);
 
   const courses = data?.courses.map(course => ({ name: course.name, slug: course.slug }))
 
@@ -38,7 +38,7 @@ export function LearningModuleCard({ data }: { data: LearningModule }): JSX.Elem
           <span className="uppercase font-semibold">{t("communities.card.module")}</span>
         </div>
         <div className="gap-2 flex items-center">
-          {challenge?.level && <Tag className="uppercase">{level}</Tag>}
+          {data?.level && <Tag className="uppercase">{level}</Tag>}
           <DurationBadge value={data.duration} type="bordered" />
         </div>
       </div>

--- a/src/components/sections/courses/_partials/Duration.tsx
+++ b/src/components/sections/courses/_partials/Duration.tsx
@@ -27,7 +27,7 @@ interface DurationProps {
  */
 export default function Duration({ text, value }: DurationProps): ReactElement {
   const colors = useSelector((state) => state.ui.colors);
-  const duration = value ? DateManager.humanize(value, "en") : 0;
+  const duration = value ? DateManager.humanize(value, "en") : "";
 
   return (
     <div>


### PR DESCRIPTION
# Submit a pull request

- [x] This is not a duplicate of an existing pull request.
- [x] No existing features have been broken without good reason.
- [x] Your commit messages are detailed
- [x] The code style guideline have been followed.
- [x] Documentation has been updated to reflect your changes.
- [x] Tests have been added or updated to reflect your changes.
- [x] All tests pass.

---

Replace any ":question:" below with information about your pull request.

## Pull Request Details

This PR aims at displaying the learning module level on both; [The learning materials](https://dev--staging-dacade.netlify.app/ko/communities/icp/learning-materials) and the [Challenge](https://dev--staging-dacade.netlify.app/communities/icp/courses/typescript-smart-contract-101) pages:question:

## Issues Fixed

- #1292 
- #1294 

## Other Relevant Information


